### PR TITLE
Incorporate temporary fix for Chrome 58 cursor detection

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/lib/redactor.js
+++ b/app/assets/javascripts/comfy/admin/cms/lib/redactor.js
@@ -7729,6 +7729,10 @@
 					{
 						var node2 = this.selection.getMarker(2);
 						this.selection.setMarker(this.range, node2, false);
+						if (this.utils.browser('chrome')) // https://github.com/concrete5/concrete5/pull/5425/commits/3482125462871f6a1a39adcdc9bdde656bfae017#diff-6a66e72e377e89b69575cc3a8f6228e6
+						{
+						    this.caret.set(node1, 0, node2, 0);
+						}
 					}
 
 					this.savedSel = this.$editor.html();


### PR DESCRIPTION
Referenced: https://github.com/concrete5/concrete5/pull/5425

This fixes the cursor positioning in Chrome 58

![2017-06-08_17-40-31](https://user-images.githubusercontent.com/62285/26917432-9e106b9e-4c71-11e7-942b-3e08df38eda6.gif)
